### PR TITLE
Solve Form Access Bug

### DIFF
--- a/src/pages/settings/settings.ts
+++ b/src/pages/settings/settings.ts
@@ -63,6 +63,11 @@ export class SettingsPage {
     });
   }
 
+  ionViewDidLoad() {
+    // Build an empty form for the template to render
+    this.form = this.formBuilder.group({});
+  }
+
   ionViewWillEnter() {
     // Build an empty form for the template to render
     this.form = this.formBuilder.group({});


### PR DESCRIPTION
There is this common issue where when you create a form it will break the code as angular will try to access it before it is actually instantiated. instead of the ioniViewWillEnter() we should go for the ionViewDidLoad() or constructor to ensure this is not the case. 