### PR TITLE
Fix delete request in API provider

### DIFF
--- a/src/providers/api.ts
+++ b/src/providers/api.ts
@@ -39,8 +39,8 @@ export class Api {
     return this.http.put(this.url + '/' + endpoint, body, options);
   }
 
-  delete(endpoint: string, body: any, options?: RequestOptions) {
-    return this.http.post(this.url + '/' + endpoint, body, options);
+  delete(endpoint: string, options?: RequestOptions) {
+    return this.http.delete(this.url + '/' + endpoint, options);
   }
 
   patch(endpoint: string, body: any, options?: RequestOptions) {


### PR DESCRIPTION
Originally this mistakenly issued a POST request instead of DELETE

Probably just a tiny oversight - overall, this template is really awesome!