### PR TITLE
update to ionic 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,5 @@
     "cordova-plugin-device",
     "cordova-plugin-splashscreen",
     "ionic-plugin-keyboard"
-  ],
-  "cordovaPlatforms": [],
-  "description": "aesuper: An Ionic project"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,49 @@
 {
+  "name": "ionic-hello-world",
+  "author": "Ionic Framework",
+  "homepage": "http://ionicframework.com/",
+  "private": true,
+  "scripts": {
+    "clean": "ionic-app-scripts clean",
+    "build": "ionic-app-scripts build",
+    "ionic:build": "ionic-app-scripts build",
+    "ionic:serve": "ionic-app-scripts serve"
+  },
   "dependencies": {
-    "ng2-translate": "^5.0.0"
-  }
+    "@angular/common": "4.0.0",
+    "@angular/compiler": "4.0.0",
+    "@angular/compiler-cli": "4.0.0",
+    "@angular/core": "^4.0.0",
+    "@angular/forms": "4.0.0",
+    "@angular/http": "4.0.0",
+    "@angular/platform-browser": "4.0.0",
+    "@angular/platform-browser-dynamic": "4.0.0",
+    "@ionic-native/camera": "^3.1.0",
+    "@ionic-native/core": "3.4.2",
+    "@ionic-native/google-maps": "3.4.2",
+    "@ionic-native/splash-screen": "3.4.2",
+    "@ionic-native/status-bar": "3.4.2",
+    "@ionic/storage": "2.0.1",
+    "@ngx-translate/core": "^6.0.1",
+    "@ngx-translate/http-loader": "0.0.3",
+    "ionic-angular": "3.0.1",
+    "ionicons": "3.0.0",
+    "rxjs": "^5.1.1",
+    "sw-toolbox": "3.4.0",
+    "zone.js": "^0.8.4"
+  },
+  "devDependencies": {
+    "@ionic/app-scripts": "1.3.0",
+    "typescript": "~2.2.1"
+  },
+  "cordovaPlugins": [
+    "cordova-plugin-whitelist",
+    "cordova-plugin-statusbar",
+    "cordova-plugin-console",
+    "cordova-plugin-device",
+    "cordova-plugin-splashscreen",
+    "ionic-plugin-keyboard"
+  ],
+  "cordovaPlatforms": [],
+  "description": "aesuper: An Ionic project"
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import {Platform, Nav, Config} from 'ionic-angular';
-import { StatusBar, Splashscreen } from 'ionic-native';
-
+import { Platform, Nav, Config } from 'ionic-angular';
+import { StatusBar } from '@ionic-native/status-bar'; 
+import { SplashScreen } from '@ionic-native/splash-screen'; 
 import { Settings } from '../providers/providers';
 
 import { FirstRunPage } from '../pages/pages';
@@ -18,7 +18,7 @@ import { MenuPage } from '../pages/menu/menu';
 import { SettingsPage } from '../pages/settings/settings';
 import { SearchPage } from '../pages/search/search';
 
-import { TranslateService } from 'ng2-translate/ng2-translate';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   template: `<ion-menu [content]="content">
@@ -59,7 +59,7 @@ export class MyApp {
     { title: 'Search', component: SearchPage }
   ]
 
-  constructor(translate: TranslateService, platform: Platform, settings: Settings, config: Config) {
+  constructor(statusBar: StatusBar, splashScreen: SplashScreen, translate: TranslateService, platform: Platform, settings: Settings, config: Config) {
     // Set the default language for translation strings, and the current language.
     translate.setDefaultLang('en');
     translate.use('en')
@@ -71,8 +71,8 @@ export class MyApp {
     platform.ready().then(() => {
       // Okay, so the platform is ready and our plugins are available.
       // Here you can do any higher level native things you might need.
-      StatusBar.styleDefault();
-      Splashscreen.hide();
+      statusBar.styleDefault();
+      splashScreen.hide();
     });
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,13 @@
 import { NgModule, ErrorHandler } from '@angular/core';
-import { Http } from '@angular/http';
+import { HttpModule, Http } from '@angular/http';
+import { BrowserModule } from '@angular/platform-browser';
 import { IonicApp, IonicModule, IonicErrorHandler } from 'ionic-angular';
 import { Storage, IonicStorageModule } from '@ionic/storage';
+
+import { Camera } from '@ionic-native/camera'; 
+import { GoogleMaps } from '@ionic-native/google-maps'; 
+import { SplashScreen } from '@ionic-native/splash-screen'; 
+import { StatusBar } from '@ionic-native/status-bar'; 
 
 import { MyApp } from './app.component';
 
@@ -25,12 +31,14 @@ import { Api } from '../providers/api';
 import { Settings } from '../providers/settings';
 import { Items } from '../mocks/providers/items';
 
-import { TranslateModule, TranslateLoader, TranslateStaticLoader } from 'ng2-translate/ng2-translate';
+import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+//TranslateStaticLoader
 
 // The translate loader needs to know where to load i18n files
 // in Ionic's static asset pipeline.
 export function createTranslateLoader(http: Http) {
-  return new TranslateStaticLoader(http, './assets/i18n', '.json');
+  return new TranslateHttpLoader(http, './assets/i18n', '.json');
 }
 
 export function provideSettings(storage: Storage) {
@@ -82,6 +90,10 @@ export function entryComponents() {
 
 export function providers() {
   return [
+    Camera,
+    GoogleMaps,
+    StatusBar,
+    SplashScreen,
     User,
     Api,
     Items,
@@ -95,13 +107,17 @@ export function providers() {
 @NgModule({
   declarations: declarations(),
   imports: [
+    BrowserModule,
+    HttpModule,
     IonicModule.forRoot(MyApp),
     IonicStorageModule.forRoot(),
     TranslateModule.forRoot({
-      provide: TranslateLoader,
-      useFactory: (createTranslateLoader),
-      deps: [Http]
-    })
+      loader: {
+        provide: TranslateLoader,
+        useFactory: createTranslateLoader,
+        deps: [Http]
+        }
+      })
   ],
   bootstrap: [IonicApp],
   entryComponents: entryComponents(),

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,7 @@
   <link rel="icon" type="image/x-icon" href="assets/icon/favicon.ico">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#4e8ef7">
-
+ 
   <!-- cordova.js required for cordova apps -->
   <script src="cordova.js"></script>
 
@@ -30,15 +30,14 @@
 
   <!-- Ionic's root component and where the app will load -->
   <ion-app></ion-app>
-
-  <script src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
   
+  <script src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
+
   <!-- The polyfills js is generated during the build process -->
   <script src="build/polyfills.js"></script>
 
   <!-- The bundle js is generated during the build process -->
   <script src="build/main.js"></script>
-
 
 </body>
 </html>

--- a/src/pages/item-create/item-create.ts
+++ b/src/pages/item-create/item-create.ts
@@ -2,7 +2,7 @@ import { Component, ViewChild } from '@angular/core';
 import { Validators, FormBuilder, FormGroup } from '@angular/forms';
 import { NavController, ViewController } from 'ionic-angular';
 
-import { Camera } from 'ionic-native';
+import { Camera } from '@ionic-native/camera';
 
 /*
   Generated class for the ItemCreate page.
@@ -23,7 +23,7 @@ export class ItemCreatePage {
 
   form: FormGroup;
 
-  constructor(public navCtrl: NavController, public viewCtrl: ViewController, formBuilder: FormBuilder) {
+  constructor(public camera: Camera, public navCtrl: NavController, public viewCtrl: ViewController, formBuilder: FormBuilder) {
     this.form = formBuilder.group({
       profilePic: [''],
       name: ['', Validators.required],
@@ -41,18 +41,15 @@ export class ItemCreatePage {
   }
 
   getPicture() {
-    if (Camera['installed']()) {
-      Camera.getPicture({
-        targetWidth: 96,
-        targetHeight: 96
-      }).then((data) => {
-        this.form.patchValue({ 'profilePic': 'data:image/jpg;base64,' +  data });
-      }, (err) => {
-        alert('Unable to take photo');
-      })
-    } else {
+    this.camera.getPicture({
+      destinationType: this.camera.DestinationType.DATA_URL,
+      targetWidth: 96,
+      targetHeight: 96
+    }).then((data) => {
+      this.form.patchValue({ 'profilePic': 'data:image/jpg;base64,' +  data });
+    }, (err) => {
       this.fileInput.nativeElement.click();
-    }
+    });
   }
 
   processWebImage(event) {

--- a/src/pages/item-create/item-create.ts
+++ b/src/pages/item-create/item-create.ts
@@ -41,15 +41,19 @@ export class ItemCreatePage {
   }
 
   getPicture() {
-    this.camera.getPicture({
-      destinationType: this.camera.DestinationType.DATA_URL,
-      targetWidth: 96,
-      targetHeight: 96
-    }).then((data) => {
-      this.form.patchValue({ 'profilePic': 'data:image/jpg;base64,' +  data });
-    }, (err) => {
-      this.fileInput.nativeElement.click();
-    });
+    if (Camera['installed']()) { 
+      this.camera.getPicture({
+        destinationType: this.camera.DestinationType.DATA_URL,
+        targetWidth: 96,
+        targetHeight: 96
+      }).then((data) => {
+        this.form.patchValue({ 'profilePic': 'data:image/jpg;base64,' +  data });
+      }, (err) => {
+        alert('Unable to take photo');
+      })
+    } else {        
+        this.fileInput.nativeElement.click();
+    }
   }
 
   processWebImage(event) {

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { NavController, ToastController } from 'ionic-angular';
 
-import { TranslateService } from 'ng2-translate/ng2-translate';
+import { TranslateService } from '@ngx-translate/core';
 
 import { MainPage } from '../../pages/pages';
 import { User } from '../../providers/user';

--- a/src/pages/map/map.ts
+++ b/src/pages/map/map.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
 import { NavController, Platform } from 'ionic-angular';
 
-import { GoogleMap, GoogleMapsLatLng } from 'ionic-native';
+import { GoogleMap, GoogleMaps, LatLng } from '@ionic-native/google-maps';
 
 declare var google: any;
 
@@ -12,7 +12,9 @@ declare var google: any;
 export class MapPage {
   @ViewChild('map') map;
 
-  constructor(public navCtrl: NavController, public platform: Platform) {}
+  googleMap: GoogleMap;
+
+  constructor(public googleMaps: GoogleMaps, public navCtrl: NavController, public platform: Platform) {}
 
   initJSMaps(mapEle) {
     new google.maps.Map(mapEle, {
@@ -22,12 +24,12 @@ export class MapPage {
   }
 
   initNativeMaps(mapEle) {
-    this.map = new GoogleMap(mapEle);
+    this.googleMap = new GoogleMap(mapEle);
     mapEle.classList.add('show-map');
 
-    GoogleMap.isAvailable().then(() => {
-      const position = new GoogleMapsLatLng(43.074395, -89.381056);
-      this.map.setPosition(position);
+    this.googleMaps.isAvailable().then(() => {
+      const position = new LatLng(43.074395, -89.381056);
+      this.googleMap.setCenter(position);
     });
   }
 

--- a/src/pages/settings/settings.ts
+++ b/src/pages/settings/settings.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { NavController, NavParams } from 'ionic-angular';
 import { Settings } from '../../providers/settings';
-import { TranslateService } from 'ng2-translate/ng2-translate';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * The Settings page is a simple form that syncs with a Settings provider

--- a/src/pages/signup/signup.ts
+++ b/src/pages/signup/signup.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { NavController, ToastController } from 'ionic-angular';
 
-import { TranslateService } from 'ng2-translate/ng2-translate';
+import { TranslateService } from '@ngx-translate/core';
 
 import { MainPage } from '../../pages/pages';
 import { User } from '../../providers/user';

--- a/src/pages/tabs/tabs.ts
+++ b/src/pages/tabs/tabs.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { NavController } from 'ionic-angular';
-import { TranslateService } from 'ng2-translate/ng2-translate';
+import { TranslateService } from '@ngx-translate/core';
 
 import { Tab1Root } from '../pages';
 import { Tab2Root } from '../pages';

--- a/src/pages/tutorial/tutorial.html
+++ b/src/pages/tutorial/tutorial.html
@@ -7,7 +7,7 @@
 </ion-header>
 
 <ion-content no-bounce>
-  <ion-slides [options]="{pager: true}" (ionWillChange)="onSlideChangeStart($event)">
+  <ion-slides pager="true" (ionWillChange)="onSlideChangeStart($event)">
     <ion-slide *ngFor="let slide of slides">
       <img [src]="slide.image" class="slide-image"/>
       <h2 class="slide-title" [innerHTML]="slide.title"></h2>

--- a/src/pages/tutorial/tutorial.ts
+++ b/src/pages/tutorial/tutorial.ts
@@ -4,7 +4,7 @@ import { MenuController, NavController } from 'ionic-angular';
 
 import { WelcomePage } from '../welcome/welcome';
 
-import { TranslateService } from 'ng2-translate/ng2-translate';
+import { TranslateService } from '@ngx-translate/core';
 
 
 

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,80 +1,30 @@
-// tick this to make the cache invalidate and update
-const CACHE_VERSION = 1;
-const CURRENT_CACHES = {
-  'read-through': 'read-through-cache-v' + CACHE_VERSION
+/**
+ * Check out https://googlechrome.github.io/sw-toolbox/docs/master/index.html for
+ * more info on how to use sw-toolbox to custom configure your service worker.
+ */
+
+
+'use strict';
+importScripts('./build/sw-toolbox.js');
+
+self.toolbox.options.cache = {
+  name: 'ionic-cache'
 };
 
-self.addEventListener('activate', (event) => {
-  // Delete all caches that aren't named in CURRENT_CACHES.
-  // While there is only one cache in this example, the same logic will handle the case where
-  // there are multiple versioned caches.
-  const expectedCacheNames = Object.keys(CURRENT_CACHES).map((key) => {
-    return CURRENT_CACHES[key];
-  });
+// pre-cache our key assets
+self.toolbox.precache(
+  [
+    './build/main.js',
+    './build/main.css',
+    './build/polyfills.js',
+    'index.html',
+    'manifest.json'
+  ]
+);
 
-  event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (expectedCacheNames.indexOf(cacheName) === -1) {
-            // If this cache name isn't present in the array of "expected" cache names, then delete it.
-            console.log('Deleting out of date cache:', cacheName);
-            return caches.delete(cacheName);
-          }
-        })
-      );
-    })
-  );
-});
+// dynamically cache any other local assets
+self.toolbox.router.any('/*', self.toolbox.cacheFirst);
 
-// This sample illustrates an aggressive approach to caching, in which every valid response is
-// cached and every request is first checked against the cache.
-// This may not be an appropriate approach if your web application makes requests for
-// arbitrary URLs as part of its normal operation (e.g. a RSS client or a news aggregator),
-// as the cache could end up containing large responses that might not end up ever being accessed.
-// Other approaches, like selectively caching based on response headers or only caching
-// responses served from a specific domain, might be more appropriate for those use cases.
-self.addEventListener('fetch', (event) => {
-
-  event.respondWith(
-    caches.open(CURRENT_CACHES['read-through']).then((cache) => {
-      return cache.match(event.request).then((response) => {
-        if (response) {
-          // If there is an entry in the cache for event.request, then response will be defined
-          // and we can just return it.
-
-          return response;
-        }
-
-        // Otherwise, if there is no entry in the cache for event.request, response will be
-        // undefined, and we need to fetch() the resource.
-        console.log(' No response for %s found in cache. ' +
-          'About to fetch from network...', event.request.url);
-
-        // We call .clone() on the request since we might use it in the call to cache.put() later on.
-        // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
-        // (see https://fetch.spec.whatwg.org/#dom-request-clone)
-        return fetch(event.request.clone()).then((response) => {
-
-          // Optional: add in extra conditions here, e.g. response.type == 'basic' to only cache
-          // responses from the same domain. See https://fetch.spec.whatwg.org/#concept-response-type
-          if (response.status < 400 && response.type === 'basic') {
-            // We need to call .clone() on the response object to save a copy of it to the cache.
-            // (https://fetch.spec.whatwg.org/#dom-request-clone)
-            cache.put(event.request, response.clone());
-          }
-
-          // Return the original response object, which will be used to fulfill the resource request.
-          return response;
-        });
-      }).catch((error) => {
-        // This catch() will handle exceptions that arise from the match() or fetch() operations.
-        // Note that a HTTP error response (e.g. 404) will NOT trigger an exception.
-        // It will return a normal response object that has the appropriate error code set.
-        console.error('  Read-through caching failed:', error);
-
-        throw error;
-      });
-    })
-  );
-});
+// for any other requests go to the network, cache,
+// and then only use that cached resource if your user goes offline
+self.toolbox.router.default = self.toolbox.networkFirst;

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -1,5 +1,7 @@
 // Ionic Variables and Theming. For more info, please see:
 // http://ionicframework.com/docs/v2/theming/
+$font-path: "../assets/fonts";
+
 @import "ionic.globals";
 
 
@@ -10,8 +12,7 @@
 // To view all the possible Ionic variables, see:
 // http://ionicframework.com/docs/v2/theming/overriding-ionic-variables/
 
-$text-color:        #000;
-$background-color:  #fff;
+
 
 
 // Named Color Variables
@@ -23,7 +24,7 @@ $background-color:  #fff;
 // The "primary" color is the only required color in the map.
 
 $colors: (
-  primary:    #387ef5,
+  primary:    #488aff,
   secondary:  #32db64,
   danger:     #f53d3d,
   light:      #f4f4f4,
@@ -67,5 +68,11 @@ $colors: (
 // The premium icon font for Ionic. For more info, please see:
 // http://ionicframework.com/docs/v2/ionicons/
 
-$ionicons-font-path: "../assets/fonts";
-@import "ionicons";
+@import "ionic.ionicons";
+
+
+// Fonts
+// --------------------------------------------------
+
+@import "roboto";
+@import "noto-sans";


### PR DESCRIPTION
Ionic View App Id 831ef985

I do not see where the maps and some other features are turned on
and I could not find the translation test form.

However this should help close the following:

https://github.com/driftyco/ionic-starter-super/issues/88
ionic v3 super template fail with ionic-native driftyco/ionic#11231
fix(ionic-native): update ionic native to 3.1.0 #84
Missing ionic-native #85
How do I test this template ? #87
Super template not compatible with ionic-native 3+ #86

```
C:\ae\ionic-starter-super>ionic info

Your system information:

 ordova CLI: 6.5.0
Ionic Framework Version: 3.0.1
Ionic CLI Version: 2.2.1
Ionic App Lib Version: 2.2.0
Ionic App Scripts Version: 1.3.0
ios-deploy version: Not installed
ios-sim version: Not installed
OS: Windows 10
Node Version: v6.10.2
Xcode version: Not installed
```

![capture061](https://cloud.githubusercontent.com/assets/140737/25077305/7d91b3f4-22dd-11e7-8562-b76da709d602.png)

