### PR TITLE
Fixed bug with angular 4 and setting HttpParams in api.ts

### DIFF
--- a/src/providers/api/api.ts
+++ b/src/providers/api/api.ts
@@ -22,7 +22,7 @@ export class Api {
     if (params) {
       reqOpts.params = new HttpParams();
       for (let k in params) {
-        reqOpts.params.set(k, params[k]);
+        reqOpts.params = reqOpts.params.set(k, params[k]);
       }
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:
See https://angular.io/api/common/http/HttpParams#set.
The `set` function will return the `HttpParams` object which must be used later.

Normally there is a `fromObject` function but it's only for angular 5.
So this solution is good for all :+1:

#### Changes proposed in this pull request:

- Fixed problem with HttpParams

**Fixes**:
#140 